### PR TITLE
Add donation link to metainfo

### DIFF
--- a/metainfo.patch
+++ b/metainfo.patch
@@ -1,8 +1,16 @@
 diff --git a/packaging/linux/net.odamex.Odamex.metainfo.xml b/packaging/linux/net.odamex.Odamex.metainfo.xml
-index d18f004d7..1a96854a5 100644
+index acbfd671a..e6bbd0e43 100644
 --- a/packaging/linux/net.odamex.Odamex.metainfo.xml
 +++ b/packaging/linux/net.odamex.Odamex.metainfo.xml
-@@ -102,6 +102,17 @@
+@@ -14,6 +14,7 @@
+   <url type="vcs-browser">https://github.com/odamex/odamex</url>
+   <url type="bugtracker">https://github.com/odamex/odamex/issues</url>
+   <url type="help">https://github.com/odamex/odamex/wiki</url>
++  <url type="donation">https://www.paypal.com/donate/?hosted_button_id=EL7NY74YC79BG</url>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-2.0-or-later</project_license>
+   <supports>
+@@ -102,6 +103,17 @@
      <color type="primary" scheme_preference="dark">#404042</color>
    </branding>
    <releases>


### PR DESCRIPTION
Just adding this into the metainfo patch until its added to the main repo in the next release.