### PR TITLE
Restrict device permissions to uri and input

### DIFF
--- a/net.odamex.Odamex.yml
+++ b/net.odamex.Odamex.yml
@@ -16,7 +16,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --filesystem=~/.odamex:create
-  - --filesystem=home # needs to be able to create banfile.json and .odalaunch config file, as well as read any odasrv cfgs
+  - --filesystem=home # needs to be able to create banfile.json and read any odasrv cfgs
   - --filesystem=host-os:ro # for standard doom data locations in /usr
   - --filesystem=host-etc:ro # standard location for timidity configs, so users can override the included one
   - --env=TIMIDITY_CFG=/app/etc/timidity.cfg

--- a/net.odamex.Odamex.yml
+++ b/net.odamex.Odamex.yml
@@ -8,7 +8,10 @@ command: select-exe
 separate-locales: false
 finish-args:
   - --share=ipc
-  - --device=all # change this to device=input + device=dri when available more widely
+  - --device=all
+  - --device-if=all:!has-input-device
+  - --device=input
+  - --device=dri
   - --socket=pulseaudio
   - --share=network
   - --socket=wayland

--- a/net.odamex.Odamex.yml
+++ b/net.odamex.Odamex.yml
@@ -8,7 +8,6 @@ command: select-exe
 separate-locales: false
 finish-args:
   - --share=ipc
-  - --device=all
   - --device-if=all:!has-input-device
   - --device=input
   - --device=dri


### PR DESCRIPTION
Now that flatpak 1.17.0 has introduced conditional permissions, we have a way to restrict the permissions without breaking controller input for users on versions of flatpak older than 1.16. 